### PR TITLE
Enable jar task

### DIFF
--- a/advabus.iml
+++ b/advabus.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="advabus" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="com.advanon" external.system.module.version="0.1.0" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="advabus" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="com.advanon" external.system.module.version="0.2.0" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ artifacts {
     archives sourcesJar
 }
 
+jar {
+    enabled = true
+}
+
 publishing {
     publications {
         AdvaBusPublication(MavenPublication) {


### PR DESCRIPTION
As per [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/html/):

> By default, when the bootJar or bootWar tasks are configured, the jar or war tasks are disabled. A project can be configured to build both an executable archive and a normal archive at the same time by enabling the jar or war task:

> jar {
	    enabled = true
  }
